### PR TITLE
Feat/org readme update

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,28 +7,66 @@
 
 ---
 
-## Explore Popular Repositories
+## Get Started
 
+OpenZeppelin provides secure smart contract libraries and tools across multiple blockchain ecosystems.
+
+Start from the [documentation](https://docs.openzeppelin.com/) to choose your ecosystem, libraries, and workflows.
+
+## Explore Highlighted Repositories by Ecosystem:
+
+### EVM (Solidity)
 - [openzeppelin-contracts](https://github.com/OpenZeppelin/openzeppelin-contracts): solidity library for secure smart contract development on Ethereum.
 - [openzeppelin-contracts-upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable): upgradeable variant of OpenZeppelin Contracts.
 - [openzeppelin-community-contracts](https://github.com/OpenZeppelin/openzeppelin-community-contracts): solidity library of smart contracts from the OpenZeppelin Community.
-- [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts): cairo library for secure smart contract development on Starknet.
-- [rust-contracts-stylus](https://github.com/OpenZeppelin/rust-contracts-stylus): rust library for secure smart contract development for Arbitrum Stylus.
 - [uniswap-hooks](https://github.com/OpenZeppelin/uniswap-hooks): solidity library for secure and modular Uniswap hooks.
-- [stellar-contracts](https://github.com/OpenZeppelin/stellar-contracts): sorobon contracts library for Stellar.
+
+### Arbitrum Stylus (Rust)
+
+- [rust-contracts-stylus](https://github.com/OpenZeppelin/rust-contracts-stylus): rust library for secure smart contract development for Arbitrum Stylus.
+
+### Confidential (Zama FHEVM)
+
 - [confidential-contracts](https://github.com/OpenZeppelin/openzeppelin-confidential-contracts): experimental library for developing on the Zama fhEVM.
+
+### Midnight
+
 - [compact-contracts](https://github.com/OpenZeppelin/midnight-contracts): compact contracts library for building on Midnight.
+
+### Polkadot
+
 - [polkadot-runtime-templates](https://github.com/OpenZeppelin/polkadot-runtime-templates): runtime templates for Polkadot parachains.
-- [Ethernaut](https://github.com/OpenZeppelin/ethernaut): interactive wargame that turns you into a Solidity security expert.
-- [Contracts Wizard](https://github.com/OpenZeppelin/contracts-wizard): instantly generate boilerplate contracts to bootstrap your next dApp.
+
+### Starknet (Cairo)
+
+- [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts): cairo library for secure smart contract development on Starknet.
+
+### Stellar (Soroban)
+
+- [stellar-contracts](https://github.com/OpenZeppelin/stellar-contracts): Soroban contracts library for Stellar.
+
+### Sui (Move)
+- [contracts-sui](https://github.com/OpenZeppelin/contracts-sui): Move contracts library for Sui. 
 
 ---
 
-## OpenZeppelin Tools
+## OpenZeppelin Tools and Learning
 
-- [Relayer](https://github.com/OpenZeppelin/openzeppelin-relayer): Infrastructure for relaying transactions on EVM and Non-EVM networks.
+- [Contracts Wizard](https://github.com/OpenZeppelin/contracts-wizard): instantly generate boilerplate contracts to bootstrap your next dApp.
+- [Ethernaut](https://github.com/OpenZeppelin/ethernaut): interactive wargame that turns you into a Solidity security expert.
 - [Monitor](https://github.com/OpenZeppelin/openzeppelin-monitor): Infrastructure tool for monitoring blockchain events and transactions.
+- [Relayer](https://github.com/OpenZeppelin/openzeppelin-relayer): Infrastructure for relaying transactions on EVM and Non-EVM networks.
+- [Role Manager](https://rolemanager.openzeppelin.com/): Open source UI tool providing your users a way to easily assess the status of the roles with your smart contracts. 
 - [UI Builder](https://github.com/OpenZeppelin/ui-builder): Open source tool for creating UI forms for contracts. 
+
+---
+
+## Build with AI
+
+OpenZeppelin provides AI-ready resources for modern development workflows.
+
+- [OpenZeppelin Skills](https://github.com/OpenZeppelin/openzeppelin-skills): agent skills for secure smart contract development with OpenZeppelin Contracts libraries.
+- [Contracts MCP](https://github.com/OpenZeppelin/openzeppelin-mcp): allowing AI agents to generate smart contracts using OpenZeppelin Contracts libraries.
 
 ---
 
@@ -44,4 +82,4 @@
 - [Telegram](https://t.me/openzeppelin_tg): Join our community of developers and stay connected. 
 - [X](https://x.com/openzeppelin): Follow us for the latest announcements and updates.
 - [Blog](https://blog.openzeppelin.com/): Dive deeper into our latest articles, security best practices, and community updates.
-- [Careers](https://www.openzeppelin.com/careers): Want to buld and secure open-source tools and protocols that protect the open economy? We’re hiring!
+- [Careers](https://www.openzeppelin.com/careers): Want to build and secure open-source tools and protocols that protect the open economy? We’re hiring!

--- a/profile/README.md
+++ b/profile/README.md
@@ -47,6 +47,7 @@ Start from the [documentation](https://docs.openzeppelin.com/) to choose your ec
 
 ### Sui (Move)
 - [contracts-sui](https://github.com/OpenZeppelin/contracts-sui): Move contracts library for Sui. 
+- [openzeppelin-sui-marketplace](https://github.com/OpenZeppelin/openzeppelin-sui-marketplace): end-to-end example of a small on-chain market on Sui.
 
 ---
 


### PR DESCRIPTION
## Documentation Pull Request

### Summary

Reorganizes the OpenZeppelin org-level `profile/README.md` so visitors can quickly find the right library for their ecosystem. Repositories are grouped by chain/runtime (EVM, Stylus, Confidential Contracts (Zama), Midnight, Polkadot, Starknet, Stellar, Sui), tools are consolidated and alphabetized, and a new "Build with AI" section surfaces the Skills and MCP resources. Also adds a top-of-page "Get Started" pointer to docs.openzeppelin.com.

### Type of Change

- [x] Restructure/reorganize content (repos grouped by ecosystem; tools split out from libraries)
- [x] New documentation (Get Started intro, Build with AI section, Sui entries, Role Manager entry)
- [x] Typo fixes

### Related Issues

No related issue.

### Companion PR

None.

### Checklist

- [x] Markdown renders correctly on the org profile page
- [x] All links resolve to live repos / pages
- [x] Docs follow [OpenZeppelin Documentation Standards](https://github.com/OpenZeppelin/docs/blob/main/STANDARDS.md)

### Additional Notes

None.